### PR TITLE
fix(ci): add SSH agent to success job for flakehub-push

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -174,6 +174,10 @@ jobs:
         if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
       - uses: DeterminateSystems/flakehub-cache-action@main
         if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
+      - uses: webfactory/ssh-agent@v0.9.0
+        if: ${{ inputs.enable-ssh-agent && !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
+        with:
+          ssh-private-key: ${{ secrets.ssh-private-key }}
       - uses: DeterminateSystems/flakehub-push@main
         if: ${{ !github.repository.fork && inputs.visibility != '' && (github.ref == format('refs/heads/{0}', inputs.default-branch) || startsWith(github.ref, 'refs/tags/')) }}
         id: publish


### PR DESCRIPTION
## Summary

- Adds `webfactory/ssh-agent` step to the `success` job before `flakehub-push`
- Uses the same conditional pattern as other publish steps, combined with `inputs.enable-ssh-agent`

## Problem

CI fails on `main` branch with `Permission denied (publickey)` when trying to fetch private SSH-based flake inputs during FlakeHub push. The SSH agent was configured for `inventory` and `build` jobs but **not** for the `success` job where `flakehub-push` runs.

## Root Cause

The `flakehub-push` action needs to evaluate the flake to publish it, which requires access to all flake inputs including private SSH-based ones. Without the SSH agent configured, the evaluation fails.

## Test plan

- [ ] Update bench repo to use this branch temporarily
- [ ] Verify CI passes on bench main branch
- [ ] Merge this fix
- [ ] Revert bench to use `main` branch of ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)