### PR TITLE
fix(workflow): use git lfs install --force for self-hosted runners

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -127,7 +127,7 @@ jobs:
             echo "$HOME/.local/bin" >> $GITHUB_PATH
             export PATH="$HOME/.local/bin:$PATH"
           fi
-          git lfs install
+          git lfs install --force
       - name: Install git-lfs (macOS)
         if: ${{ inputs.enable-lfs && runner.os == 'macOS' }}
         run: |
@@ -140,7 +140,7 @@ jobs:
             echo "$HOME/.local/bin" >> $GITHUB_PATH
             export PATH="$HOME/.local/bin:$PATH"
           fi
-          git lfs install
+          git lfs install --force
       - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.enable-lfs }}
@@ -211,7 +211,7 @@ jobs:
             echo "$HOME/.local/bin" >> $GITHUB_PATH
             export PATH="$HOME/.local/bin:$PATH"
           fi
-          git lfs install
+          git lfs install --force
       - name: Install git-lfs (macOS)
         if: ${{ inputs.enable-lfs && runner.os == 'macOS' }}
         run: |
@@ -224,7 +224,7 @@ jobs:
             echo "$HOME/.local/bin" >> $GITHUB_PATH
             export PATH="$HOME/.local/bin:$PATH"
           fi
-          git lfs install
+          git lfs install --force
       - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.enable-lfs }}


### PR DESCRIPTION
## Summary
- Uses `git lfs install --force` instead of `git lfs install` on self-hosted runners

## Problem
Self-hosted runners can have stale git LFS configuration from previous runs (similar to the existing `http.extraHeader` cleanup at line 202). When `filter.lfs.clean` is set to `cat` (from debugging or other workflows), `git lfs install` fails:

```
warning: the "filter.lfs.clean" attribute should be "git-lfs clean -- %f" but is "cat"
```

## Solution
The `--force` flag ensures a clean LFS config regardless of existing state, matching the pattern used for other git config cleanup on self-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)