### PR TITLE
ci: test LFS pointer by header string, not file size

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -150,17 +150,16 @@ jobs:
           # Verify LFS files are actually smudged (not pointers)
           if git lfs ls-files | head -1 | grep -q '^'; then
             echo "✅ LFS files present"
-            # Check first LFS file is not a pointer (pointers are ~130 bytes)
-            # Use cut instead of awk for NixOS compatibility
+            # Detect pointers by header string, not size — small smudged blobs are valid
             first_lfs_file=$(git lfs ls-files | head -1 | cut -d' ' -f3-)
             if [ -n "$first_lfs_file" ] && [ -f "$first_lfs_file" ]; then
-              file_size=$(wc -c < "$first_lfs_file")
-              if [ "$file_size" -gt 200 ]; then
-                echo "✅ LFS file '$first_lfs_file' is smudged (${file_size} bytes)"
-              else
-                echo "❌ LFS file '$first_lfs_file' appears to be a pointer (${file_size} bytes)"
+              if head -c 100 "$first_lfs_file" | grep -q '^version https://git-lfs.github.com/spec/v1'; then
+                echo "❌ LFS file '$first_lfs_file' appears to be an unsmudged pointer"
                 head -c 200 "$first_lfs_file"
                 exit 1
+              else
+                file_size=$(wc -c < "$first_lfs_file")
+                echo "✅ LFS file '$first_lfs_file' is smudged (${file_size} bytes)"
               fi
             fi
           else


### PR DESCRIPTION
## Summary
- Replace the size-threshold heuristic (`file_size -gt 200`) with a content-based check for the literal `version https://git-lfs.github.com/spec/v1` header in the first 100 bytes.
- Legitimately tiny smudged LFS files (e.g. a 107-byte zstd fixture in purescript-dedup) were being misdiagnosed as unsmudged pointers.

## Context
Needed to unblock CI on purescript-dedup PR Cambridge-Vision-Technology/purescript-dedup#47, where `test/fixtures/credential-handling/recording-standard-0.85.zstd` is a real 107-byte zstd recording starting with magic bytes `28 B5 2F FD`, not a pointer.

## Test plan
- [x] Downstream purescript-dedup PR #47 CI re-run after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)