### PR TITLE
Authenticate git CLI on runner to github.com (#14)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       - run: nix run nixpkgs#actionlint -- ./.github/workflows/workflow.yml ./.github/workflows/validate.yml
       - run: nix run nixpkgs#nodePackages.prettier -- --check .
 
-  CI:
+  ci:
     uses: ./.github/workflows/workflow.yml
     permissions:
       contents: read

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -140,6 +140,21 @@ jobs:
         with:
           lfs: ${{ inputs.enable-lfs }}
           fetch-depth: 0 # Full clone for LFS compatibility
+      - name: Authenticate git / Nix to github.com
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # ~/.netrc for the git CLI subprocess (and other tools that honour netrc)
+          printf 'machine github.com\nlogin x-access-token\npassword %s\n' "$GITHUB_TOKEN" > "${HOME}/.netrc"
+          chmod 600 "${HOME}/.netrc"
+          # /tmp/netrc for Nix (wired into determinate-nix-action via netrc-file)
+          printf 'machine github.com\nlogin x-access-token\npassword %s\n' "$GITHUB_TOKEN" > /tmp/netrc
+          chmod 600 /tmp/netrc
+          # git credential helper for any code path that ignores netrc
+          git config --global credential.helper store
+          echo "https://x-access-token:${GITHUB_TOKEN}@github.com" > "${HOME}/.git-credentials"
+          chmod 600 "${HOME}/.git-credentials"
       - name: Ensure LFS files are checked out
         if: ${{ inputs.enable-lfs }}
         run: |
@@ -165,23 +180,6 @@ jobs:
           else
             echo "ℹ️ No LFS files in repository"
           fi
-      - name: Create netrc for Nix
-        run: |
-          touch /tmp/netrc
-          chmod 600 /tmp/netrc
-      # Configure credentials for LFS - netrc for Nix's HTTP requests
-      # NOTE: Do NOT set git config --global http.extraHeader - it breaks Nix fetching public repos
-      - name: Configure credentials for LFS
-        if: ${{ inputs.enable-lfs }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          # Configure git credential helper for LFS operations
-          git config --global credential.helper store
-          echo "https://x-access-token:${GITHUB_TOKEN}@github.com" >> ~/.git-credentials
-          # Create netrc for Nix's HTTP requests (used by Nix for fetching)
-          echo "machine github.com login x-access-token password ${GITHUB_TOKEN}" > /tmp/netrc
-          chmod 600 /tmp/netrc
       - name: Clean up stale magic-nix-cache daemon
         run: pkill -f magic-nix-cache || true
       - uses: DeterminateSystems/determinate-nix-action@v3

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,51 @@
+# Plan: Authenticate git CLI on runner to avoid GitHub rate-limiting (#14)
+
+## DELIVERABLES
+
+A reviewer with no knowledge of the implementation can verify completion by checking that:
+
+1. **Unconditional authentication step.** `.github/workflows/workflow.yml` contains a step (e.g. `Authenticate git / Nix to github.com`) that runs on *every* invocation of the reusable workflow — i.e. it is **not** guarded by `if: ${{ inputs.enable-lfs }}`.
+2. **`~/.netrc` is written for the git subprocess.** The step produces a `~/.netrc` (mode 600) containing `machine github.com`, `login x-access-token`, and the value of `${{ github.token }}` as password.
+3. **`/tmp/netrc` is written for Nix.** The step produces `/tmp/netrc` (mode 600) with the same credentials, and Nix is configured via `netrc-file = /tmp/netrc` (existing wiring preserved).
+4. **Git credential helper is configured.** The step sets `git config --global credential.helper store` and writes `https://x-access-token:<token>@github.com` to `~/.git-credentials` (preserving existing LFS behavior).
+5. **No `http.extraHeader` regression.** The workflow does not set `git config --global http.extraHeader` (already CLAUDE.md guidance — a regression guard).
+6. **End-to-end: downstream flake check succeeds.** blackbriar#222 (the PR that exposed the rate-limit symptoms) passes `nix flake check` on x86_64-linux when pinned against this branch of `ci`, demonstrating the authenticated path works for transitive `builtins.fetchGit` calls (purs-nix et al.). Existing tests (`workflow-structure`, `runner-map-transform`) remain green.
+
+---
+
+## PHASE 1 — Authenticate git CLI and Nix to github.com
+
+Single phase; ~half a day total. One developer.
+
+### CHUNK 1 — Add failing BDD-style workflow tests
+
+Add a new test directory `tests/authenticate-github/` with a `test.sh` (wired via `nix flake check` the same way existing tests are) that asserts the deliverable contract against `.github/workflows/workflow.yml`:
+
+- A step named `Authenticate git / Nix to github.com` (or equivalent) **exists**.
+- That step has **no `if:` condition** referencing `enable-lfs`.
+- That step's `env` includes `GITHUB_TOKEN: ${{ github.token }}`.
+- That step's `run` block writes `${HOME}/.netrc`, `/tmp/netrc`, `~/.git-credentials`, and sets `credential.helper store`.
+- The old conditional step `Configure credentials for LFS` no longer exists (or has been renamed and ungated).
+- Regression guard: no `http.extraHeader` is set globally anywhere in the workflow.
+
+Run `nix flake check` and confirm the new test file fails. Commit red tests.
+
+### CHUNK 2 — Implement the unconditional auth step
+
+Modify `.github/workflows/workflow.yml` to replace `Configure credentials for LFS` with an unconditional `Authenticate git / Nix to github.com` step matching the sketch in the issue. Keep the existing `Create netrc for Nix` bootstrap step (or fold it in — developer's call) and the existing `netrc-file = /tmp/netrc` wiring to `determinate-nix-action`.
+
+Run `nix run .#format-fix` then `nix flake check` — new tests + existing tests all green. Commit.
+
+### CHUNK 3 — Live verification via blackbriar#222
+
+Push branch; the draft PR's own validate.yml runs end-to-end on x86_64-linux and aarch64-darwin runners — confirm green.
+
+Then point blackbriar#222 at this branch (temporarily change its `uses:` reference to `Cambridge-Vision-Technology/ci/.github/workflows/workflow.yml@issue-14-authenticate-git-cli`) and re-run its failing `nix flake check`. Success there — specifically, the previously failing transitive `github.com/purescript/*` and `github.com/id3as/*` clones completing without 5xx / TCP drops — is the primary live-fire evidence the fix works. Revert the blackbriar branch reference before merging this PR (the consumer will pick the fix up via `@main`).
+
+---
+
+**Notes for the developer:**
+
+- Tests here are workflow-YAML contract tests — that's the "user-observable surface" of a reusable workflow. Dynamic runner behavior is proven by the live CI run on the PR itself + blackbriar#222.
+- Do not add backward-compat shims. Just replace the step.
+- Keep the commit sequence: red test → implementation → green.

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,7 +17,9 @@ A reviewer with no knowledge of the implementation can verify completion by chec
 
 Single phase; ~half a day total. One developer.
 
-### CHUNK 1 — Add failing BDD-style workflow assertions
+### CHUNK 1 — Add failing BDD-style workflow assertions ✅ **Done.**
+
+> Note: required a preparatory commit (`3142f77`) to remove obsolete flakehub-cache-action assertions that predated the auth work — those failures were unrelated to #14 and were dropped because flakehub-cache-action was intentionally removed in `0df45d0`.
 
 **Extend `tests/workflow-structure/test.sh`** — do NOT create a new `tests/authenticate-github/` directory. `workflow-structure` is already the home for workflow-YAML contract assertions (step existence, regression guards, step-config checks). A new directory duplicates the `nix flake check` derivation wiring and slows the test suite for no gain.
 
@@ -32,7 +34,9 @@ Add these assertions to `tests/workflow-structure/test.sh`:
 
 Run `nix flake check` and confirm the new assertions fail. Commit red tests.
 
-### CHUNK 2 — Implement the unconditional auth step
+### CHUNK 2 — Implement the unconditional auth step ✅ **Done.**
+
+> Note: `~/.git-credentials` is now always written, not just when `enable-lfs: true`. Intentional widening (previously the file was only written under the LFS gate).
 
 Modify `.github/workflows/workflow.yml` to replace `Configure credentials for LFS` with an unconditional `Authenticate git / Nix to github.com` step matching the sketch in the issue. Fold the now-redundant `Create netrc for Nix` bootstrap step into the new step (the new step unconditionally writes `/tmp/netrc` itself, so the bootstrap is dead code — per CLAUDE.md "delete code; don't comment out"). Preserve:
 
@@ -46,7 +50,9 @@ The plan's statement "preserving existing LFS behavior" is slightly misleading: 
 
 Run `nix run .#format-fix` then `nix flake check` — new tests + existing tests all green. Commit.
 
-### CHUNK 3 — Live verification via blackbriar#222
+### CHUNK 3 — Live verification via blackbriar#222 ✅ **Done.**
+
+> Note: blackbriar#222 auto-merged with the temporary `@issue-14-authenticate-git-cli` pin in place while verification was running, so `blackbriar/main` briefly pointed at this branch. Revert PR opened as blackbriar#227. Verification run: https://github.com/Cambridge-Vision-Technology/blackbriar/actions/runs/24876784289
 
 Push branch; the draft PR's own validate.yml runs end-to-end on x86_64-linux and aarch64-darwin runners — confirm green.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -17,22 +17,32 @@ A reviewer with no knowledge of the implementation can verify completion by chec
 
 Single phase; ~half a day total. One developer.
 
-### CHUNK 1 — Add failing BDD-style workflow tests
+### CHUNK 1 — Add failing BDD-style workflow assertions
 
-Add a new test directory `tests/authenticate-github/` with a `test.sh` (wired via `nix flake check` the same way existing tests are) that asserts the deliverable contract against `.github/workflows/workflow.yml`:
+**Extend `tests/workflow-structure/test.sh`** — do NOT create a new `tests/authenticate-github/` directory. `workflow-structure` is already the home for workflow-YAML contract assertions (step existence, regression guards, step-config checks). A new directory duplicates the `nix flake check` derivation wiring and slows the test suite for no gain.
+
+Add these assertions to `tests/workflow-structure/test.sh`:
 
 - A step named `Authenticate git / Nix to github.com` (or equivalent) **exists**.
 - That step has **no `if:` condition** referencing `enable-lfs`.
 - That step's `env` includes `GITHUB_TOKEN: ${{ github.token }}`.
 - That step's `run` block writes `${HOME}/.netrc`, `/tmp/netrc`, `~/.git-credentials`, and sets `credential.helper store`.
 - The old conditional step `Configure credentials for LFS` no longer exists (or has been renamed and ungated).
-- Regression guard: no `http.extraHeader` is set globally anywhere in the workflow.
+- Regression guard: no `http.extraHeader` is set globally anywhere in the workflow. (Note: the existing `Clean up stale git extraHeader config` step that *unsets* stale config must be preserved — assert presence, not absence.)
 
-Run `nix flake check` and confirm the new test file fails. Commit red tests.
+Run `nix flake check` and confirm the new assertions fail. Commit red tests.
 
 ### CHUNK 2 — Implement the unconditional auth step
 
-Modify `.github/workflows/workflow.yml` to replace `Configure credentials for LFS` with an unconditional `Authenticate git / Nix to github.com` step matching the sketch in the issue. Keep the existing `Create netrc for Nix` bootstrap step (or fold it in — developer's call) and the existing `netrc-file = /tmp/netrc` wiring to `determinate-nix-action`.
+Modify `.github/workflows/workflow.yml` to replace `Configure credentials for LFS` with an unconditional `Authenticate git / Nix to github.com` step matching the sketch in the issue. Fold the now-redundant `Create netrc for Nix` bootstrap step into the new step (the new step unconditionally writes `/tmp/netrc` itself, so the bootstrap is dead code — per CLAUDE.md "delete code; don't comment out"). Preserve:
+
+- The existing `Clean up stale git extraHeader config` step (regression guard for self-hosted runners carrying stale config from a previous workflow version).
+- The `netrc-file = /tmp/netrc` wiring to `determinate-nix-action`.
+- The existing `git-lfs` install + `Ensure LFS files are checked out` steps (gated on `enable-lfs`).
+
+The new step's `run` block must start with `set -euo pipefail` (CLAUDE.md shell-safety rule; existing steps in this workflow are inconsistent here — the new step should not repeat that lapse).
+
+The plan's statement "preserving existing LFS behavior" is slightly misleading: removing the `enable-lfs` guard means `~/.git-credentials` is now always written. That is the intended widening, not regression — call it out in the commit message.
 
 Run `nix run .#format-fix` then `nix flake check` — new tests + existing tests all green. Commit.
 

--- a/tests/workflow-structure/test.sh
+++ b/tests/workflow-structure/test.sh
@@ -263,6 +263,105 @@ else
   fail "Validate devShells step does not have correct if condition"
 fi
 
+# --- Authenticate git / Nix to github.com: step exists (issue #14) ---
+
+if grep -qE 'name: Authenticate git / Nix to github\.com' "$WORKFLOW"; then
+  pass "Authenticate git / Nix to github.com step exists"
+else
+  fail "Authenticate git / Nix to github.com step does not exist"
+fi
+
+# --- Extract the Authenticate step block for further assertions ---
+
+authenticate_block=""
+in_step=false
+while IFS= read -r line; do
+  if [[ "$line" == *"name: Authenticate git / Nix to github.com"* ]]; then
+    in_step=true
+    authenticate_block+="$line"$'\n'
+    continue
+  fi
+  if $in_step; then
+    if [[ "$line" =~ ^[[:space:]]{6}-[[:space:]]+(name:|uses:) ]]; then
+      break
+    fi
+    authenticate_block+="$line"$'\n'
+  fi
+done < "$WORKFLOW"
+
+# --- Authenticate step is unconditional (no if: referencing enable-lfs) ---
+
+if echo "$authenticate_block" | grep -qE '^\s*if:.*enable-lfs'; then
+  fail "Authenticate step has an if: condition referencing enable-lfs (must be unconditional)"
+else
+  pass "Authenticate step has no if: enable-lfs guard"
+fi
+
+# --- Authenticate step env includes GITHUB_TOKEN: ${{ github.token }} ---
+
+if echo "$authenticate_block" | grep -qE 'GITHUB_TOKEN:[[:space:]]*\$\{\{[[:space:]]*github\.token[[:space:]]*\}\}'; then
+  pass "Authenticate step sets GITHUB_TOKEN: \${{ github.token }} in env"
+else
+  fail "Authenticate step does not set GITHUB_TOKEN: \${{ github.token }} in env"
+fi
+
+# --- Authenticate step writes ${HOME}/.netrc ---
+
+if echo "$authenticate_block" | grep -qE '\$\{?HOME\}?/\.netrc|~/.netrc'; then
+  pass "Authenticate step writes to \${HOME}/.netrc"
+else
+  fail "Authenticate step does not write to \${HOME}/.netrc"
+fi
+
+# --- Authenticate step writes /tmp/netrc ---
+
+if echo "$authenticate_block" | grep -q '/tmp/netrc'; then
+  pass "Authenticate step writes to /tmp/netrc"
+else
+  fail "Authenticate step does not write to /tmp/netrc"
+fi
+
+# --- Authenticate step writes ~/.git-credentials ---
+
+if echo "$authenticate_block" | grep -qE '~/\.git-credentials|\$\{?HOME\}?/\.git-credentials'; then
+  pass "Authenticate step writes to ~/.git-credentials"
+else
+  fail "Authenticate step does not write to ~/.git-credentials"
+fi
+
+# --- Authenticate step configures credential.helper store ---
+
+if echo "$authenticate_block" | grep -qE 'credential\.helper[[:space:]]+store'; then
+  pass "Authenticate step sets credential.helper store"
+else
+  fail "Authenticate step does not set credential.helper store"
+fi
+
+# --- Old conditional 'Configure credentials for LFS' step is removed ---
+
+if grep -qE 'name: Configure credentials for LFS' "$WORKFLOW"; then
+  fail "old 'Configure credentials for LFS' step still exists (should be removed/renamed)"
+else
+  pass "old 'Configure credentials for LFS' step has been removed"
+fi
+
+# --- Regression guard: no git config --global http.extraHeader (setting) ---
+
+extra_header_hits="$(grep -E 'git config --global[^|]*http\..*\.extraHeader' "$WORKFLOW" | grep -vE -- '--unset' || true)"
+if [ -n "$extra_header_hits" ]; then
+  fail "workflow sets git config --global http.extraHeader (regression)"
+else
+  pass "workflow does not set git config --global http.extraHeader"
+fi
+
+# --- Preserve existing 'Clean up stale git extraHeader config' step ---
+
+if grep -qE 'name: Clean up stale git extraHeader config' "$WORKFLOW"; then
+  pass "'Clean up stale git extraHeader config' step is preserved"
+else
+  fail "'Clean up stale git extraHeader config' step is missing (must be preserved)"
+fi
+
 # --- Summary ---
 
 echo ""

--- a/tests/workflow-structure/test.sh
+++ b/tests/workflow-structure/test.sh
@@ -189,36 +189,12 @@ else
   fail "build job does not use determinate-nix-action"
 fi
 
-# --- Build job uses flakehub-cache-action ---
-
-if echo "$build_block" | grep -qi 'flakehub-cache-action'; then
-  pass "build job uses flakehub-cache-action"
-else
-  fail "build job does not use flakehub-cache-action"
-fi
-
 # --- Build job has cleanup step for stale magic-nix-cache ---
 
 if echo "$build_block" | grep -qE 'pkill.*magic-nix-cache'; then
   pass "build job has magic-nix-cache cleanup step"
 else
   fail "build job does not have magic-nix-cache cleanup step"
-fi
-
-# --- flakehub-cache-action uses startup-notification-port: 0 ---
-
-if echo "$build_block" | grep -q 'startup-notification-port.*0'; then
-  pass "flakehub-cache-action uses startup-notification-port: 0"
-else
-  fail "flakehub-cache-action does not use startup-notification-port: 0"
-fi
-
-# --- flakehub-cache-action uses listen: 127.0.0.1:0 ---
-
-if echo "$build_block" | grep -q 'listen.*127\.0\.0\.1:0'; then
-  pass "flakehub-cache-action uses listen: 127.0.0.1:0"
-else
-  fail "flakehub-cache-action does not use listen: 127.0.0.1:0"
 fi
 
 # --- Build job has id-token: write ---


### PR DESCRIPTION
closes #14

See PLAN.md for deliverables and chunked approach.

## Summary

- Widen the existing `Configure credentials for LFS` step so it runs on every invocation and writes `~/.netrc` in addition to `/tmp/netrc`, letting the `builtins.fetchGit` git subprocess use the runner's GITHUB_TOKEN.
- Live verification via blackbriar#222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)