### PR TITLE
feat(flake): wire tests into checks and add format-fix app

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,36 @@
           in
           f { inherit pkgs; }
         );
+
+      repoSource = lib.fileset.toSource {
+        root = ./.;
+        fileset = lib.fileset.unions [
+          ./.github
+          ./tests
+        ];
+      };
+
+      mkShellTest =
+        pkgs: name:
+        pkgs.runCommand "test-${name}"
+          {
+            nativeBuildInputs = [
+              pkgs.bash
+              pkgs.jq
+              pkgs.yq-go
+              pkgs.gnugrep
+              pkgs.gnused
+              pkgs.coreutils
+            ];
+          }
+          ''
+            set -e
+            cp -r ${repoSource} repo
+            chmod -R u+w repo
+            cd repo
+            bash tests/${name}/test.sh
+            touch $out
+          '';
     in
     {
 
@@ -38,6 +68,8 @@
             buildInputs = [
               pkgs.nodePackages.prettier
               pkgs.actionlint
+              pkgs.jq
+              pkgs.yq-go
               agen.packages.${pkgs.system}.default
             ];
 
@@ -45,6 +77,41 @@
               # Regenerate CLAUDE.md from agents.yaml and company guidance
               agen >&2
             '';
+          };
+        }
+      );
+
+      checks = forEachSystem (
+        { pkgs }:
+        {
+          workflow-structure = mkShellTest pkgs "workflow-structure";
+          runner-map-transform = mkShellTest pkgs "runner-map-transform";
+        }
+      );
+
+      apps = forEachSystem (
+        { pkgs }:
+        {
+          format-fix = {
+            type = "app";
+            program =
+              let
+                script = pkgs.writeShellApplication {
+                  name = "format-fix";
+                  runtimeInputs = [ pkgs.nodePackages.prettier ];
+                  text = ''
+                    set -euo pipefail
+                    prettier --write \
+                      --ignore-path .gitignore \
+                      --no-error-on-unmatched-pattern \
+                      "**/*.yml" \
+                      "**/*.yaml" \
+                      "**/*.json" \
+                      "**/*.md"
+                  '';
+                };
+              in
+              "${script}/bin/format-fix";
           };
         }
       );

--- a/tests/workflow-structure/test.sh
+++ b/tests/workflow-structure/test.sh
@@ -189,36 +189,12 @@ else
   fail "build job does not use determinate-nix-action"
 fi
 
-# --- Build job uses flakehub-cache-action ---
-
-if echo "$build_block" | grep -qi 'flakehub-cache-action'; then
-  pass "build job uses flakehub-cache-action"
-else
-  fail "build job does not use flakehub-cache-action"
-fi
-
 # --- Build job has cleanup step for stale magic-nix-cache ---
 
 if echo "$build_block" | grep -qE 'pkill.*magic-nix-cache'; then
   pass "build job has magic-nix-cache cleanup step"
 else
   fail "build job does not have magic-nix-cache cleanup step"
-fi
-
-# --- flakehub-cache-action uses startup-notification-port: 0 ---
-
-if echo "$build_block" | grep -q 'startup-notification-port.*0'; then
-  pass "flakehub-cache-action uses startup-notification-port: 0"
-else
-  fail "flakehub-cache-action does not use startup-notification-port: 0"
-fi
-
-# --- flakehub-cache-action uses listen: 127.0.0.1:0 ---
-
-if echo "$build_block" | grep -q 'listen.*127\.0\.0\.1:0'; then
-  pass "flakehub-cache-action uses listen: 127.0.0.1:0"
-else
-  fail "flakehub-cache-action does not use listen: 127.0.0.1:0"
 fi
 
 # --- Build job has id-token: write ---


### PR DESCRIPTION
## Summary

- Expose `tests/workflow-structure/test.sh` and `tests/runner-map-transform/test.sh` as `checks.<system>.*` derivations so `nix flake check` actually runs them. Previously the flake only exposed `devShells`, so `nix flake check` passed trivially regardless of test state.
- Add `apps.<system>.format-fix` (wraps `prettier --write` over YAML/JSON/Markdown) so `nix run .#format-fix` — which `CLAUDE.md` has long referenced — actually exists.
- Drop four obsolete assertions in `tests/workflow-structure/test.sh` that referenced `flakehub-cache-action`, `startup-notification-port`, and `listen: 127.0.0.1:0`. These were stale as of 0df45d0 (which removed flakehub-cache-action from the workflow) but were never detected because the tests were not wired in.
- Add `jq` and `yq-go` to the devShell so tests are runnable standalone from `nix develop`.

## Motivation

Surfaced during work on #14: two independent agent sessions noticed that `nix flake check` passes trivially and that `format-fix` was missing despite `CLAUDE.md` referring to it. The `workflow-structure` test had diverged from reality (asserting on wiring removed in 0df45d0) yet CI stayed green. Wiring the tests in prevents this class of silent regression.

## Test plan

- [x] `nix flake check` runs both test derivations and they pass (aarch64-darwin)
- [x] `nix run .#format-fix` executes, formats the repo, exits 0
- [x] `tests/workflow-structure/test.sh` passes standalone (17/17)
- [x] `tests/runner-map-transform/test.sh` passes standalone (8/8)
- [ ] CI green on the PR

## Notes

- `tests/smoke/` is a consumer-side fixture flake (no `test.sh`), so it's not wired in as a check. Left untouched.
- The existing devShell's `pkgs.nodePackages.prettier` attribute is retained; the pinned weekly nixpkgs still has `nodePackages`, even though current unstable nixpkgs has moved it to top-level `pkgs.prettier`.

Generated with [Claude Code](https://claude.com/claude-code)