### PR TITLE
chore: add auto-merge-automated caller

### DIFF
--- a/.github/workflows/auto-merge-automated.yml
+++ b/.github/workflows/auto-merge-automated.yml
@@ -1,0 +1,13 @@
+name: auto-merge-automated
+
+on:
+  check_suite:
+    types: [completed]
+
+jobs:
+  auto-merge:
+    if: github.event.check_suite.conclusion == 'success'
+    uses: Cambridge-Vision-Technology/maintenance/.github/workflows/auto-merge.yml@main
+    secrets:
+      AUTO_UPDATE_APP_ID: ${{ secrets.AUTO_UPDATE_APP_ID }}
+      AUTO_UPDATE_APP_PRIVATE_KEY: ${{ secrets.AUTO_UPDATE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the per-repo `auto-merge-automated.yml` caller for the reusable `Cambridge-Vision-Technology/maintenance/.github/workflows/auto-merge.yml` workflow.

Part of maintenance Phase 5.3 — this enables app-token-driven auto-merge for `automated/*` PRs (preserving the propagation chain that GITHUB_TOKEN auto-merge would suppress).