### PR TITLE
feat(auth): let callers narrow organization read access to named repositories

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,6 +19,12 @@ on:
         required: false
         default: false
         type: boolean
+      org-read-repositories:
+        description: |
+          Optional narrowing of `enable-org-read-access`. Comma- or newline-separated repository names, either `repository` or `owner/repository` where the owner has to be this organization. Empty — the default — grants read access to every repository in this organization, which is what this workflow has always done. Narrow it when the job's private dependencies are a known, fixed list; leave it empty when they are not, as a flake whose inputs may change is.
+        required: false
+        default: ""
+        type: string
       visibility:
         description: "[DEPRECATED] No longer used. Will be removed in a future version."
         required: false
@@ -180,6 +186,16 @@ jobs:
         with:
           lfs: ${{ inputs.enable-lfs }}
           fetch-depth: 0 # Full clone for LFS compatibility
+      # The token stays owner-wide unless the caller narrows it. The action
+      # splits `repositories` on commas and newlines and drops empty entries, so
+      # the empty default leaves it with no repository at all, and an `owner`
+      # with no repositories is precisely its whole-organization case. Passing
+      # the input unconditionally is therefore identical to omitting the line,
+      # and there is deliberately no fallback expression here: a `||` would
+      # silently narrow the default path to one repository. This workflow
+      # resolves whatever private flake inputs the consumer's flake declares, so
+      # a narrowed list is only ever correct when the consumer knows that list;
+      # the empty default is what keeps every existing caller working.
       - name: Mint GitHub App organization installation token
         id: github-app-token
         if: ${{ inputs.enable-org-read-access || inputs.enable-github-app-auth }}
@@ -188,6 +204,7 @@ jobs:
           app-id: ${{ secrets.github-app-id }}
           private-key: ${{ secrets.github-app-private-key }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ inputs.org-read-repositories }}
           permission-contents: read
       # job.workflow_repository / job.workflow_sha identify this repository at
       # the revision the caller selected, with no hard-coded repository and with

--- a/README.md
+++ b/README.md
@@ -84,6 +84,42 @@ They can be dropped from every call site once the token source moves to an STS (
 
 <!-- prettier-ignore-end -->
 
+### Narrowing the scope
+
+`org-read-repositories` is **optional**, and leaving it unset is the supported default.
+Unset, the job can read **every repository in your organisation** — exactly what enabling the capability has always meant, so no existing call site changes.
+
+Set it when the job's private dependencies are a known, fixed list, and you would rather it could not read anything else:
+
+```yaml
+jobs:
+  CI:
+    uses: $YOURORG/ci/.github/workflows/workflow.yml@main
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      enable-org-read-access: true
+      org-read-repositories: nix-shared, infra-base
+    secrets:
+      github-app-id: ${{ secrets.CI_FETCH_APP_ID }}
+      github-app-private-key: ${{ secrets.CI_FETCH_APP_PRIVATE_KEY }}
+```
+
+Names are comma- or newline-separated, and each is either `repository` or `owner/repository` where the owner must be your own organisation.
+The input is named for the **scope of the access**, not for the mechanism: a token, an STS trust policy (DEV-753) and every plausible successor all express scope as a list of repositories, so narrowing survives the mechanism moving.
+
+Leave it unset when the list is not knowable in advance — a flake whose inputs change, or a repository that pulls in transitive private inputs it does not name.
+A narrowed job that reaches for a repository outside the list fails at fetch time with a `404`, which reads as "repository not found" rather than as a permission error.
+
+<!-- prettier-ignore-start -->
+
+> [!TIP]
+> Narrowing is worth the maintenance only where the dependency list is stable.
+> If you find yourself editing `org-read-repositories` every time a flake input moves, the honest configuration is the organisation-wide default.
+
+<!-- prettier-ignore-end -->
+
 ## Choosing a surface
 
 Three surfaces expose the same capability. Pick the smallest one that fits.
@@ -94,7 +130,7 @@ Three surfaces expose the same capability. Pick the smallest one that fits.
 | `setup/action.yml`               | A bespoke job that needs the same setup — authentication, Nix, optional ssh-agent, optional LFS — but is not shaped like a flake check. For example a `tofu plan` job.            |
 | `auth/action.yml`                | Any job that needs credentials only, including a self-hosted job that manages its own checkout and Nix. This is what makes pasting a token-mint block into your repo unnecessary. |
 
-All three take `enable-org-read-access` and run the same `auth/authenticate.sh` implementation, at the revision you selected in `uses:`.
+All three take `enable-org-read-access` and its optional `org-read-repositories` narrowing, and run the same `auth/authenticate.sh` implementation, at the revision you selected in `uses:`.
 Only `auth/action.yml` exposes an output, `org-read-token`, as an escape hatch for tools it cannot configure — `gh`, for instance, reads neither the git credential helper nor Nix's `netrc-file`.
 Prefer the environment side effect.
 
@@ -155,6 +191,7 @@ An input marked `?lfs=1` therefore needs no SSH key — only `enable-org-read-ac
 | :----------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------- |
 | `enable-org-read-access` | Whether the job may read every repository in your organisation, including private flake inputs and their Git LFS objects. Requires the `github-app-id` and `github-app-private-key` secrets. | `false`                                                                          |
 | `enable-github-app-auth` | **Deprecated** alias for `enable-org-read-access`, on this workflow only. Removed only after the organisation-wide sweep of call sites (DEV-760); use `enable-org-read-access`.              | `false`                                                                          |
+| `org-read-repositories`  | **Optional.** Comma- or newline-separated `repository` or `owner/repository` names the organisation read access is confined to. Empty means every repository in your organisation.           | `""` (organisation-wide)                                                         |
 | `enable-ssh-agent`       | **Deprecated**, still accepted. Whether to enable [`webfactory/ssh-agent`][ssh-agent] in the workflow. If you set this to `true` you need to supply a secret named `ssh-private-key`.        | `false`                                                                          |
 | `enable-lfs`             | Whether to enable Git LFS when checking out the repository. Set to `true` if your repository uses Git LFS for large files.                                                                   | `false`                                                                          |
 | `check-dev-shells`       | Whether to validate devShells by running `nix develop --command true`. Set to `false` if your devShells are expensive or unavailable on some systems.                                        | `true`                                                                           |

--- a/auth/action.yml
+++ b/auth/action.yml
@@ -31,6 +31,18 @@ inputs:
       authenticates with `github-token`, which reaches its own repository only.
     required: false
     default: "false"
+  org-read-repositories:
+    description: |
+      Optional narrowing of `enable-org-read-access`. Comma- or
+      newline-separated repository names, either `repository` or
+      `owner/repository` where the owner has to be this organization. Empty —
+      the default — grants read access to every repository in this
+      organization, which is what this action has always done. Narrow it when
+      the job's private dependencies are a known, fixed list; leave it empty
+      when they are not, as a flake whose inputs may change is. Ignored unless
+      `enable-org-read-access` is `'true'`.
+    required: false
+    default: ""
   github-app-id:
     description: |
       GitHub App ID used to mint the organization read token. Ignored unless
@@ -123,6 +135,13 @@ runs:
         echo "::error::$guard_message"
         exit 1
 
+    # The token stays owner-wide unless the caller narrows it. The action splits
+    # `repositories` on commas and newlines and drops empty entries, so the
+    # empty default leaves it with no repository at all, and an `owner` with no
+    # repositories is precisely its whole-organization case. Passing the input
+    # unconditionally is therefore identical to omitting the line, and there is
+    # deliberately no fallback expression here: a `||` would silently narrow the
+    # default path to one repository.
     - name: Mint GitHub App organization installation token
       id: org-read-app-token
       if: ${{ inputs.enable-org-read-access == 'true' }}
@@ -131,6 +150,7 @@ runs:
         app-id: ${{ inputs.github-app-id }}
         private-key: ${{ inputs.github-app-private-key }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ inputs.org-read-repositories }}
         permission-contents: read
 
     - name: Authenticate git and Nix to github.com

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -25,6 +25,18 @@ inputs:
       and `github-app-private-key`.
     required: false
     default: "false"
+  org-read-repositories:
+    description: |
+      Optional narrowing of `enable-org-read-access`. Comma- or
+      newline-separated repository names, either `repository` or
+      `owner/repository` where the owner has to be this organization. Empty —
+      the default — grants read access to every repository in this
+      organization, which is what this composite has always done. Narrow it
+      when the job's private dependencies are a known, fixed list; leave it
+      empty when they are not, as a flake whose inputs may change is. Ignored
+      unless organization read access is enabled.
+    required: false
+    default: ""
   github-app-id:
     description: |
       GitHub App ID used to mint the organization read token. Ignored unless
@@ -144,6 +156,13 @@ runs:
         lfs: ${{ inputs.enable-lfs == 'true' }}
         fetch-depth: ${{ inputs.fetch-depth }}
 
+    # The token stays owner-wide unless the caller narrows it. The action splits
+    # `repositories` on commas and newlines and drops empty entries, so the
+    # empty default leaves it with no repository at all, and an `owner` with no
+    # repositories is precisely its whole-organization case. Passing the input
+    # unconditionally is therefore identical to omitting the line, and there is
+    # deliberately no fallback expression here: a `||` would silently narrow the
+    # default path to one repository.
     - name: Mint GitHub App organization installation token
       id: org-read-app-token
       if: ${{ inputs.enable-org-read-access == 'true' }}
@@ -152,6 +171,7 @@ runs:
         app-id: ${{ inputs.github-app-id }}
         private-key: ${{ inputs.github-app-private-key }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ inputs.org-read-repositories }}
         permission-contents: read
 
     - name: Detect existing Nix

--- a/tests/setup-action-structure/test.sh
+++ b/tests/setup-action-structure/test.sh
@@ -362,6 +362,139 @@ for composite in "$ACTION" "$AUTH_ACTION"; do
   fi
 done
 
+# --- Optional repository scoping narrows the capability, and nothing else ---
+#
+# enable-org-read-access grants read access to every repository in the
+# organization. A caller whose private dependencies are a known, fixed list
+# should be able to say so without giving up the shared implementation, so
+# org-read-repositories confines the minted token to a named list.
+#
+# It is a PURE ADDITION. The App token action splits `repositories` on commas
+# and newlines and drops empty entries, so the empty default leaves it with no
+# repository at all, and an `owner` with no repositories is exactly its
+# whole-organization case. An unset input therefore mints precisely the token
+# this repository has always minted, which is what every assertion below about
+# the default path is protecting.
+#
+# The name is scope-shaped, never mechanism-shaped. Octo STS trust policies
+# carry a `repositories` field just as an App installation token does, so the
+# input survives the move off App secrets (DEV-753) without a second
+# organization-wide sweep of call sites.
+
+extract_action_input() {
+  awk -v key="  $1:" '
+    $0 == key { in_input = 1; next }
+    in_input && /^  [a-zA-Z]/ { exit }
+    in_input { print }
+  ' "$2"
+}
+
+extract_step_from() {
+  awk -v needle="name: $1" '
+    index($0, needle) && !in_step { in_step = 1; print; next }
+    !in_step { next }
+    /^[[:space:]]*-[[:space:]]+(name:|uses:)/ { exit }
+    { print }
+  ' "$2"
+}
+
+mint_step_name='Mint GitHub App organization installation token'
+mechanism_named_scope_inputs=(
+  github-app-repositories
+  app-repositories
+  token-repositories
+  installation-repositories
+)
+
+for scoped_surface in "$ACTION" "$AUTH_ACTION"; do
+  scoped_surface_label="${scoped_surface#"$REPO_ROOT"/}"
+
+  if grep -qE '^[[:space:]]+org-read-repositories:' "$scoped_surface"; then
+    pass "$scoped_surface_label exposes the optional repository scope input org-read-repositories"
+  else
+    fail "$scoped_surface_label does not expose org-read-repositories, so a caller cannot narrow below organization-wide"
+  fi
+
+  scope_input_block="$(extract_action_input org-read-repositories "$scoped_surface")"
+  scope_description="$(printf '%s\n' "$scope_input_block" | tr '\n' ' ' | tr -s ' ')"
+
+  if printf '%s\n' "$scope_input_block" | grep -qE '^[[:space:]]+required: false[[:space:]]*$'; then
+    pass "org-read-repositories stays optional in $scoped_surface_label"
+  else
+    fail "org-read-repositories is not optional in $scoped_surface_label"
+  fi
+
+  if printf '%s\n' "$scope_input_block" | grep -qE '^[[:space:]]+default: ""[[:space:]]*$'; then
+    pass "org-read-repositories defaults to empty in $scoped_surface_label, which is the organization-wide token minted today"
+  else
+    fail "org-read-repositories does not default to empty in $scoped_surface_label, so it would change the behaviour of existing callers"
+  fi
+
+  if [[ "$scope_description" == *"every repository in this organization"* ]]; then
+    pass "$scoped_surface_label documents that the empty default is organization-wide"
+  else
+    fail "$scoped_surface_label does not document what the empty default of org-read-repositories means"
+  fi
+
+  mint_block="$(extract_step_from "$mint_step_name" "$scoped_surface")"
+
+  if printf '%s\n' "$mint_block" | grep -qF 'repositories: ${{ inputs.org-read-repositories }}'; then
+    pass "$scoped_surface_label wires org-read-repositories to create-github-app-token's repositories input"
+  else
+    fail "$scoped_surface_label declares org-read-repositories but never wires it to create-github-app-token's repositories input"
+  fi
+
+  scope_wirings="$(count_occurrences 'repositories: ${{ inputs.org-read-repositories }}' "$scoped_surface")"
+  if [ "$scope_wirings" -eq 1 ]; then
+    pass "org-read-repositories is wired exactly once in $scoped_surface_label"
+  else
+    fail "$scoped_surface_label wires org-read-repositories $scope_wirings times, expected exactly 1"
+  fi
+
+  # A fallback expression is the one edit that would silently narrow the default
+  # path: `${{ inputs.org-read-repositories || github.repository }}` looks
+  # harmless and confines every existing caller to its own repository.
+  scope_fallbacks="$(awk '/^[[:space:]]*#/ { next } index($0, "repositories: ${{") && index($0, "||") { count++ } END { print count + 0 }' "$scoped_surface")"
+  if [ "$scope_fallbacks" -eq 0 ]; then
+    pass "the repository scope in $scoped_surface_label carries no fallback expression, so an unset input stays empty"
+  else
+    fail "$scoped_surface_label has $scope_fallbacks fallback expressions on the repositories input, which would narrow the default path"
+  fi
+
+  mint_owner_line="$(printf '%s\n' "$mint_block" | awk 'index($0, "owner:") { sub(/^[[:space:]]*/, ""); print; exit }')"
+  if [ "$mint_owner_line" = 'owner: ${{ github.repository_owner }}' ]; then
+    pass "$scoped_surface_label still mints against the whole owner installation, unconditionally"
+  else
+    fail "$scoped_surface_label mints with owner line '$mint_owner_line', expected the unconditional repository owner"
+  fi
+
+  # Setting only the scope must mint nothing: the capability input alone decides
+  # whether a token exists at all, and the scope decides only how wide it is.
+  mint_gate_line="$(printf '%s\n' "$mint_block" | awk 'index($0, "if:") { sub(/^[[:space:]]*/, ""); print; exit }')"
+  if [[ "$mint_gate_line" != *"org-read-repositories"* ]]; then
+    pass "$scoped_surface_label does not let org-read-repositories gate whether a token is minted"
+  else
+    fail "$scoped_surface_label gates token minting on org-read-repositories, so the scope input changes whether a token exists"
+  fi
+
+  for mechanism_named_scope_input in "${mechanism_named_scope_inputs[@]}"; do
+    if grep -qF "$mechanism_named_scope_input" "$scoped_surface"; then
+      fail "$scoped_surface_label names the repository scope after the mechanism: $mechanism_named_scope_input"
+    else
+      pass "$scoped_surface_label carries no mechanism-named repository scope input: $mechanism_named_scope_input"
+    fi
+  done
+done
+
+# The scope is decided when the token is minted and is invisible below that: the
+# shared script receives a token and never learns how wide it is. That is what
+# makes this a pure addition rather than a second code path.
+if grep -qiE 'org.read.repositories' "$AUTH_SCRIPT"; then
+  fail "auth/authenticate.sh knows about the repository scope, so credential writing now has more than one path"
+else
+  pass "auth/authenticate.sh never sees the repository scope, so the credential-writing implementation is unchanged"
+fi
+
 # --- The auth action's contract is an environment side effect ---
 
 if grep -qE '^[[:space:]]{2}token:' "$AUTH_ACTION"; then

--- a/tests/workflow-structure/test.sh
+++ b/tests/workflow-structure/test.sh
@@ -420,6 +420,116 @@ else
   fail "GitHub App token is not downscoped to contents: read"
 fi
 
+# --- Optional repository scoping narrows the capability, and nothing else ---
+#
+# enable-org-read-access grants read access to every repository in the
+# organization. A caller whose private dependencies are a known, fixed list
+# should be able to say so without abandoning this workflow for a hand-rolled
+# job, so org-read-repositories confines the minted token to a named list.
+#
+# It is a PURE ADDITION. The App token action splits `repositories` on commas
+# and newlines and drops empty entries, so the empty default leaves it with no
+# repository at all, and an `owner` with no repositories is exactly its
+# whole-organization case. An unset input therefore mints precisely the token
+# this workflow has always minted — which matters more here than on the
+# composites, because roughly 27 repositories consume this workflow at @main.
+#
+# The name is scope-shaped, never mechanism-shaped. Octo STS trust policies
+# carry a `repositories` field just as an App installation token does, so the
+# input survives the move off App secrets (DEV-753) without a second
+# organization-wide sweep of call sites.
+
+extract_workflow_input() {
+  awk -v key="      $1:" '
+    $0 == key { in_input = 1; next }
+    in_input && /^      [a-zA-Z]/ { exit }
+    in_input { print }
+  ' "$WORKFLOW"
+}
+
+if grep -qE '^      org-read-repositories:' "$WORKFLOW"; then
+  pass "the workflow exposes the optional repository scope input org-read-repositories"
+else
+  fail "the workflow does not expose org-read-repositories, so a caller cannot narrow below organization-wide"
+fi
+
+scope_input_block="$(extract_workflow_input org-read-repositories)"
+scope_description="$(printf '%s\n' "$scope_input_block" | tr '\n' ' ' | tr -s ' ')"
+
+if printf '%s\n' "$scope_input_block" | grep -qE '^[[:space:]]+required: false[[:space:]]*$'; then
+  pass "org-read-repositories stays optional on the workflow"
+else
+  fail "org-read-repositories is not optional on the workflow, so every existing call site would have to pass it"
+fi
+
+if printf '%s\n' "$scope_input_block" | grep -qE '^[[:space:]]+default: ""[[:space:]]*$'; then
+  pass "org-read-repositories defaults to empty, which is the organization-wide token this workflow mints today"
+else
+  fail "org-read-repositories does not default to empty, so it would change the behaviour of existing callers"
+fi
+
+# A list of names is a string, not a boolean. A workflow_call input with the
+# wrong type is a startup failure at every call site that sets it.
+if printf '%s\n' "$scope_input_block" | grep -qE '^[[:space:]]+type: string[[:space:]]*$'; then
+  pass "org-read-repositories is declared as a string, matching the list the App token action parses"
+else
+  fail "org-read-repositories is not declared type: string"
+fi
+
+if [[ "$scope_description" == *"every repository in this organization"* ]]; then
+  pass "the workflow documents that the empty default of org-read-repositories is organization-wide"
+else
+  fail "the workflow does not document what the empty default of org-read-repositories means"
+fi
+
+if echo "$app_token_block" | grep -qF 'repositories: ${{ inputs.org-read-repositories }}'; then
+  pass "the workflow wires org-read-repositories to create-github-app-token's repositories input"
+else
+  fail "the workflow declares org-read-repositories but never wires it to create-github-app-token's repositories input"
+fi
+
+workflow_scope_wirings="$(count_occurrences 'repositories: ${{ inputs.org-read-repositories }}' "$WORKFLOW")"
+if [ "$workflow_scope_wirings" -eq 1 ]; then
+  pass "org-read-repositories is wired exactly once in the workflow"
+else
+  fail "the workflow wires org-read-repositories $workflow_scope_wirings times, expected exactly 1"
+fi
+
+# A fallback expression is the one edit that would silently narrow the default
+# path: `${{ inputs.org-read-repositories || github.repository }}` looks
+# harmless and confines every existing caller to its own repository.
+workflow_scope_fallbacks="$(awk '/^[[:space:]]*#/ { next } index($0, "repositories: ${{") && index($0, "||") { count++ } END { print count + 0 }' "$WORKFLOW")"
+if [ "$workflow_scope_fallbacks" -eq 0 ]; then
+  pass "the repository scope carries no fallback expression, so an unset input stays empty"
+else
+  fail "the workflow has $workflow_scope_fallbacks fallback expressions on the repositories input, which would narrow the default path"
+fi
+
+workflow_mint_owner_line="$(echo "$app_token_block" | awk 'index($0, "owner:") { sub(/^[[:space:]]*/, ""); print; exit }')"
+if [ "$workflow_mint_owner_line" = 'owner: ${{ github.repository_owner }}' ]; then
+  pass "the workflow still mints against the whole owner installation, unconditionally"
+else
+  fail "the workflow mints with owner line '$workflow_mint_owner_line', expected the unconditional repository owner"
+fi
+
+# Setting only the scope must mint nothing: the capability input and its
+# deprecated alias alone decide whether a token exists, and the scope decides
+# only how wide it is.
+workflow_mint_gate_line="$(echo "$app_token_block" | awk 'index($0, "if:") { sub(/^[[:space:]]*/, ""); print; exit }')"
+if [ "$workflow_mint_gate_line" = 'if: ${{ inputs.enable-org-read-access || inputs.enable-github-app-auth }}' ]; then
+  pass "the mint gate is unchanged: only the capability input and its deprecated alias decide whether a token is minted"
+else
+  fail "the mint gate is '$workflow_mint_gate_line', expected the capability input and its deprecated alias alone"
+fi
+
+for mechanism_named_scope_input in github-app-repositories app-repositories token-repositories installation-repositories; do
+  if grep -qF "$mechanism_named_scope_input" "$WORKFLOW"; then
+    fail "the workflow names the repository scope after the mechanism: $mechanism_named_scope_input"
+  else
+    pass "the workflow carries no mechanism-named repository scope input: $mechanism_named_scope_input"
+  fi
+done
+
 # --- Credential acquisition is delegated to the single shared script ---
 
 delegation_block="$(extract_named_build_step 'Check out shared authentication implementation')"
@@ -941,6 +1051,22 @@ for ordinary_job in lints ci setup-composite-smoke; do
     pass "ordinary validation job $ordinary_job is not gated on the probe opt-in"
   fi
 done
+
+# The probes are the only live evidence that organization read access works, and
+# the organization-wide default is the path every existing consumer takes, so no
+# probe may narrow the scope. One that passed org-read-repositories would prove a
+# narrowed token and leave the default unproven.
+scoped_probe_jobs=""
+for probe_job in "${probe_jobs[@]}"; do
+  if extract_validate_job "$probe_job" | grep -qF 'org-read-repositories'; then
+    scoped_probe_jobs="$scoped_probe_jobs$probe_job "
+  fi
+done
+if [ -z "$scoped_probe_jobs" ]; then
+  pass "every probe exercises the organization-wide default scope, so the probe evidence covers the path existing consumers take"
+else
+  fail "probes '$scoped_probe_jobs' narrow the repository scope, so the organization-wide default path is unproven"
+fi
 
 # --- The reusable-workflow probe ---
 


### PR DESCRIPTION
## What

Adds an optional `org-read-repositories` input to all three surfaces — `.github/workflows/workflow.yml`, `setup/action.yml` and `auth/action.yml` — that confines the minted organization read token to a named list of repositories.

```yaml
with:
  enable-org-read-access: true
  org-read-repositories: nix-shared, infra-base
```

Comma- or newline-separated, `repository` or `owner/repository`, owner must be your own organization. Unset means organization-wide, exactly as today.

## Why

`maintenance` (DEV-754) should converge on this composite rather than keep its own token-mint block, but it mints a token for a **single repository** today. Without a way to narrow, adopting the shared implementation would be a strict expansion of the credential it holds — a regression traded for deduplication. This lets it adopt the shared code and keep the scope it already has.

The input is named for the **scope of the access**, not the mechanism. An Octo STS trust policy expresses scope as a list of repositories exactly as an App installation token does, so the DEV-753 swap off App secrets will not require a second organization-wide sweep of call sites.

## The default is verifiably identical

This workflow is consumed at `@main` by roughly 27 repositories, so the unset path has to be byte-identical in behaviour. Verified against `actions/create-github-app-token` at the pinned `bcd2ba49218906704ab6c1aa796996da409d3eb1`, in both `main.js`/`lib/main.js` and the shipped `dist/main.cjs`:

- `action.yml` declares `repositories` with **no `default:`**, so no value is injected when the key is omitted.
- `core.getInput` is `process.env[INPUT_REPOSITORIES] || ""` — an absent env var and an empty one are indistinguishable, both `""`.
- Parsing is `getInput("repositories").split(/[\n,]+/).map(s => s.trim()).filter(x => x !== "")`, so `""` yields `[]` in both cases.
- `resolveInstallationTarget` then takes `if (owner && repositories.length === 0)` → `{ type: "owner", owner }` → `GET /users/{owner}/installation` with **no** `repositoryNames` restriction — the whole-organization token.

So passing `repositories: ${{ inputs.org-read-repositories }}` unconditionally with the empty default is identical to omitting the line.

Also verified unchanged versus `origin/main`, byte for byte:

- the mint step's `if:` gate on every surface — setting only the scope mints nothing
- `owner: ${{ github.repository_owner }}`, still unconditional on all three
- the `bcd2ba4` pin — not bumped
- `auth/authenticate.sh` — untouched; the shared script never learns how wide the token is, so there is no second credential-writing path
- the input and secret key sets — exactly one key added per surface, nothing removed

There is deliberately **no fallback expression** on the wiring. `${{ inputs.org-read-repositories || github.repository }}` would look harmless and silently confine all 27 consumers to their own repository; a test asserts its absence on each surface.

## Tests

610 assertions, all passing — up from 568 on `origin/main` (+27 in `tests/setup-action-structure`, +15 in `tests/workflow-structure`).

| Suite | Assertions |
| :-- | --: |
| `tests/runner-map-transform` | 8 |
| `tests/setup-action-structure` | 232 |
| `tests/workflow-structure` | 370 |

The new assertions cover: the input is `required: false` with `default: ""` (and `type: string` on the workflow), it is wired exactly once per surface, it carries no `||` fallback, `owner:` stays unconditional, the mint gate does not mention it, the name is not mechanism-shaped, `auth/authenticate.sh` never sees it, and no probe job narrows the scope — so the probe evidence keeps covering the organization-wide path existing consumers take.

`actionlint`, `prettier --check .` and `nix flake check` are all clean.
